### PR TITLE
BerkshelfのrbenvレシピでRubyを入れる様に修正

### DIFF
--- a/nodes/storyboards001.json
+++ b/nodes/storyboards001.json
@@ -1,1 +1,1 @@
-{"run_list":["unicorn-scripts", "base", "storyboards-app-base", "nodejs", "screenshot"]}
+{"run_list":["unicorn-scripts", "base", "storyboards-app-base", "nodejs", "screenshot", "ruby"]}


### PR DESCRIPTION
- 解決したいこと
 - storyboards001コンテナに対してrbenvがapt経由でインストールされていたのでこれをBerksehlfのrbenvでインストールする様に修正