### PR TITLE
Add cron for manage001

### DIFF
--- a/nodes/manage001.json
+++ b/nodes/manage001.json
@@ -1,1 +1,1 @@
-{"run_list":["base", "ruby", "nodejs", "manage"]}
+{"run_list":["base", "ruby", "nodejs", "manage", "cron"]}

--- a/site-cookbooks/cron/recipes/default.rb
+++ b/site-cookbooks/cron/recipes/default.rb
@@ -41,6 +41,15 @@ cron "Daily report" do
   only_if {node['hostname'] == "remp001"}
 end
 
+### For manage001 container.
+cron "Hubot restart" do
+  user "remper"
+  command "supervisorctl restart Hubot"
+  hour "08"
+  minute "00"
+  only_if {node['hostname'] == "manage001"}
+end
+
 # Cron restart.
 service "cron" do
   action :restart


### PR DESCRIPTION
### 解決したいこと
- ```manage001``` コンテナで稼働させているSlackアダプタを利用したHubotが自然に退室するので強制的に再起動をかけて再接続させます。
